### PR TITLE
Add message metadata and REST management for chat history

### DIFF
--- a/src/agent_host/app/models.py
+++ b/src/agent_host/app/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 
@@ -14,6 +15,17 @@ class ChatChunk(BaseModel):
 class ChatResponse(BaseModel):
     text: str
     used_tools: List[Dict[str, Any]] = []
+
+class ChatMessage(BaseModel):
+    message_id: str
+    role: str
+    content: str
+    created_at: datetime
+    updated_at: datetime
+
+class ChatMessagePatch(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
 
 class MemoryItem(BaseModel):
     memory_id: Optional[str] = None

--- a/src/agent_host/app/orchestrator/history.py
+++ b/src/agent_host/app/orchestrator/history.py
@@ -1,16 +1,36 @@
-import os, json, io
-from typing import List, Dict
+import os
+import json
+from datetime import datetime
+from typing import Any, Dict, List
+from uuid import uuid4
 
 def _hist_path(root: str, agent_id: str) -> str:
     base = os.path.join(root, agent_id)
     os.makedirs(base, exist_ok=True)
     return os.path.join(base, "chat_history.jsonl")
 
-def load_history(root: str, agent_id: str, max_pairs: int = 20) -> List[Dict[str, str]]:
-    path = _hist_path(root, agent_id)
-    msgs: List[Dict[str, str]] = []
+def _now_ts() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+def _normalize_record(raw: Dict[str, Any]) -> Dict[str, Any]:
+    if "role" not in raw or "content" not in raw:
+        raise ValueError("history records require role and content")
+    record: Dict[str, Any] = {
+        "message_id": raw.get("message_id") or uuid4().hex,
+        "role": raw["role"],
+        "content": raw["content"],
+        "created_at": raw.get("created_at") or _now_ts(),
+    }
+    record["updated_at"] = raw.get("updated_at") or record["created_at"]
+    for key, value in raw.items():
+        if key not in record:
+            record[key] = value
+    return record
+
+def _read_records(path: str) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
     if not os.path.exists(path):
-        return msgs
+        return records
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
@@ -18,26 +38,69 @@ def load_history(root: str, agent_id: str, max_pairs: int = 20) -> List[Dict[str
                 continue
             try:
                 obj = json.loads(line)
-                if "role" in obj and "content" in obj:
-                    msgs.append({"role": obj["role"], "content": obj["content"]})
+                record = _normalize_record(obj)
             except Exception:
                 continue
-    # keep last 2*max_pairs messages
-    if len(msgs) > 2*max_pairs:
-        msgs = msgs[-2*max_pairs:]
-    return msgs
+            records.append(record)
+    return records
 
-def append_turn(root: str, agent_id: str, role: str, content: str):
+def load_all_turns(root: str, agent_id: str) -> List[Dict[str, Any]]:
     path = _hist_path(root, agent_id)
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps({"role": role, "content": content}, ensure_ascii=False) + "\n")
+    return _read_records(path)
 
-def write_all(root: str, agent_id: str, msgs: List[Dict[str, str]]):
+def load_history(root: str, agent_id: str, max_pairs: int = 20) -> List[Dict[str, Any]]:
+    records = load_all_turns(root, agent_id)
+    if len(records) > 2 * max_pairs:
+        records = records[-2 * max_pairs:]
+    return records
+
+def append_turn(root: str, agent_id: str, role: str, content: str, *, message_id: str | None = None) -> Dict[str, Any]:
+    path = _hist_path(root, agent_id)
+    ts = _now_ts()
+    record = {
+        "message_id": message_id or uuid4().hex,
+        "role": role,
+        "content": content,
+        "created_at": ts,
+        "updated_at": ts,
+    }
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return record
+
+def write_all(root: str, agent_id: str, msgs: List[Dict[str, Any]]):
     path = _hist_path(root, agent_id)
     with open(path, "w", encoding="utf-8") as f:
         for m in msgs:
-            f.write(json.dumps({"role": m["role"], "content": m["content"]}, ensure_ascii=False) + "\n")
+            record = _normalize_record(m)
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+def update_turn(root: str, agent_id: str, message_id: str, patch: Dict[str, Any]) -> bool:
+    path = _hist_path(root, agent_id)
+    records = _read_records(path)
+    updated = False
+    for rec in records:
+        if rec["message_id"] == message_id:
+            for key, value in patch.items():
+                if key == "message_id":
+                    continue
+                rec[key] = value
+            rec["updated_at"] = _now_ts()
+            updated = True
+            break
+    if updated:
+        write_all(root, agent_id, records)
+    return updated
+
+def delete_turn(root: str, agent_id: str, message_id: str) -> bool:
+    path = _hist_path(root, agent_id)
+    records = _read_records(path)
+    new_records = [rec for rec in records if rec["message_id"] != message_id]
+    if len(new_records) == len(records):
+        return False
+    write_all(root, agent_id, new_records)
+    return True
 
 def clear_history(root: str, agent_id: str):
     path = _hist_path(root, agent_id)
-    open(path, "w").close()
+    open(path, "w", encoding="utf-8").close()

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,4 +1,17 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
 from agent_host.app.orchestrator import history as H
+from agent_host.app import main as main_app
+
+
+def _prompt_view(msgs):
+    return [{"role": m["role"], "content": m["content"]} for m in msgs]
+
 
 def test_history_roundtrip(tmp_path):
     root = tmp_path.as_posix()
@@ -9,20 +22,86 @@ def test_history_roundtrip(tmp_path):
     assert msgs == []
 
     # Append a user and assistant turn
-    H.append_turn(root, agent, "user", "hi")
-    H.append_turn(root, agent, "assistant", "hello")
+    user = H.append_turn(root, agent, "user", "hi")
+    assist = H.append_turn(root, agent, "assistant", "hello")
 
     msgs = H.load_history(root, agent, max_pairs=20)
     assert len(msgs) == 2
-    assert msgs[0]["role"] == "user" and msgs[0]["content"] == "hi"
-    assert msgs[1]["role"] == "assistant" and msgs[1]["content"] == "hello"
+    assert _prompt_view(msgs)[0] == {"role": "user", "content": "hi"}
+    assert _prompt_view(msgs)[1] == {"role": "assistant", "content": "hello"}
+    assert user["message_id"] != assist["message_id"]
+    assert user["created_at"] <= user["updated_at"]
 
     # External edit (simulate manual file change)
     H.write_all(root, agent, [{"role": "user", "content": "edited"}])
     msgs2 = H.load_history(root, agent, max_pairs=20)
-    assert msgs2 == [{"role": "user", "content": "edited"}]
+    assert len(msgs2) == 1
+    assert _prompt_view(msgs2)[0] == {"role": "user", "content": "edited"}
+    assert "message_id" in msgs2[0]
 
     # Clear
     H.clear_history(root, agent)
     msgs3 = H.load_history(root, agent, max_pairs=20)
     assert msgs3 == []
+
+
+def test_update_and_delete_turn(tmp_path):
+    root = tmp_path.as_posix()
+    agent = "agent"
+
+    first = H.append_turn(root, agent, "user", "hi")
+    second = H.append_turn(root, agent, "assistant", "hello")
+
+    updated = H.update_turn(root, agent, first["message_id"], {"content": "updated"})
+    assert updated is True
+    after_update = H.load_all_turns(root, agent)
+    updated_first = next(m for m in after_update if m["message_id"] == first["message_id"])
+    assert updated_first["content"] == "updated"
+    assert updated_first["updated_at"] >= first["updated_at"]
+
+    deleted = H.delete_turn(root, agent, second["message_id"])
+    assert deleted is True
+    remaining = H.load_all_turns(root, agent)
+    assert len(remaining) == 1
+    assert remaining[0]["message_id"] == first["message_id"]
+
+    missing = H.delete_turn(root, agent, "does-not-exist")
+    assert missing is False
+
+
+def test_history_endpoints(tmp_path, monkeypatch):
+    root = tmp_path.as_posix()
+    agent = "agent-api"
+
+    monkeypatch.setattr(main_app, "CHROMA_PERSIST_ROOT", root, raising=False)
+    client = TestClient(main_app.app)
+
+    first = H.append_turn(root, agent, "user", "hi")
+    second = H.append_turn(root, agent, "assistant", "hello")
+
+    resp = client.get(f"/agents/{agent}/history")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert len(payload["history"]) == 2
+    assert payload["history"][0]["message_id"] == first["message_id"]
+
+    resp = client.put(
+        f"/agents/{agent}/history/{first['message_id']}",
+        json={"content": "updated"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    resp = client.get(f"/agents/{agent}/history")
+    payload = resp.json()
+    assert payload["history"][0]["content"] == "updated"
+
+    resp = client.delete(f"/agents/{agent}/history/{second['message_id']}")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    resp = client.get(f"/agents/{agent}/history")
+    payload = resp.json()
+    assert len(payload["history"]) == 1
+    assert payload["history"][0]["message_id"] == first["message_id"]


### PR DESCRIPTION
## Summary
- add message IDs and timestamps to stored chat history with helpers for updating and deleting turns
- introduce Pydantic models and update the orchestrator to consume the richer history structures while persisting generated IDs
- expose REST endpoints for managing chat history and cover the new functionality with tests

## Testing
- pytest tests/test_history.py

------
https://chatgpt.com/codex/tasks/task_e_68daf94812588332a2a9530a54387ccc