### PR TITLE
Fix Pydantic defaults and extend memory query schema

### DIFF
--- a/src/agent_host/app/models.py
+++ b/src/agent_host/app/models.py
@@ -14,7 +14,7 @@ class ChatChunk(BaseModel):
 
 class ChatResponse(BaseModel):
     text: str
-    used_tools: List[Dict[str, Any]] = []
+    used_tools: List[Dict[str, Any]] = Field(default_factory=list)
 
 class ChatMessage(BaseModel):
     message_id: str
@@ -31,9 +31,9 @@ class MemoryItem(BaseModel):
     memory_id: Optional[str] = None
     type: str
     text: str
-    tags: List[str] = []
+    tags: List[str] = Field(default_factory=list)
     salience: float = 0.5
-    metadata: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = Field(default_factory=dict)
     created_at: Optional[str] = None
     last_seen_at: Optional[str] = None
 
@@ -41,6 +41,7 @@ class RetrieveQuery(BaseModel):
     agent_id: str = "default"
     query: str
     k: int = 6
+    where: Optional[Dict[str, Any]] = None
 
 class AgentProfile(BaseModel):
     agent_id: str


### PR DESCRIPTION
## Summary
- use `Field(default_factory=...)` for list and dict attributes in the API models to avoid shared mutable defaults
- add the optional `where` filter to `RetrieveQuery` so the model matches the memory.retrieve tool contract

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db310e204083328515a9e27244c7a7